### PR TITLE
Implement S3 feed publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,36 @@ And then periodically run it to keep the data fresh
 
 ### Publishing backends
 
-- S3
-- ActiveStorage
-- Rails cache
-- Static file
-- FTP
+#### S3
+
+Configuration, inside an initializer:
+
+```ruby
+Aws.config[:profile] = 'my-profile'
+s3 = SolidusFeeds::Publishers::S3.new(object_key: "foo/bar.txt", bucket: "my-bucket")
+```
+
+```ruby
+Aws.config[:profile] = 'my-profile'
+s3 = SolidusFeeds::Publishers::S3.new(object_key: "foo/bar.txt", bucket: "my-bucket", client: Aws::S3::Client.new(…)) # see docs
+```
+
+```ruby
+SolidusFeeds.register :all_products do |feed|
+  feed.generator = SolidusFeeds::Generators::GoogleMerchant.new(Spree::Product.all)
+  feed.publisher = SolidusFeeds::Puslishers::S3.new(
+    bucket: "foo",
+    object_key: "bar/my_feed.xml"
+  )
+
+  # visit https://s3.us-east-1.amazonaws.com/foo/bar/my_feed.xml
+end
+```
+
+#### ActiveStorage
+#### Rails cache
+#### Static file
+#### FTP
 
 ### Builtin Generators
 

--- a/lib/solidus_feeds.rb
+++ b/lib/solidus_feeds.rb
@@ -7,3 +7,5 @@ require 'solidus_feeds/version'
 require 'solidus_feeds/feed'
 require 'solidus_feeds/feeds'
 require 'solidus_feeds/engine'
+
+require 'solidus_feeds/publishers/s3'

--- a/lib/solidus_feeds/publishers/s3.rb
+++ b/lib/solidus_feeds/publishers/s3.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'aws-sdk-s3'
+
+module SolidusFeeds
+  module Publishers
+    class S3
+      attr_reader :object_key, :bucket, :resource
+
+      NoContentError = Class.new(StandardError)
+
+      def initialize(object_key:, bucket:, client: Aws::S3::Client.new)
+        @object_key = object_key
+        @bucket = bucket
+        @resource = Aws::S3::Resource.new(client: client)
+      end
+
+      def call
+        Tempfile.create(object_key) do |io|
+          yield io
+          io.rewind
+          raise NoContentError, "no content was generated" if io.eof?
+
+          object = resource.bucket(bucket).object(object_key)
+          object.put(body: io, acl: 'public-read')
+        end
+      end
+    end
+  end
+end

--- a/solidus_feeds.gemspec
+++ b/solidus_feeds.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables = files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'aws-sdk-s3', '~> 1.83'
   spec.add_dependency 'solidus_core', ['>= 2.0.0', '< 3']
   spec.add_dependency 'solidus_support', '~> 0.5'
 

--- a/spec/lib/solidus_feeds/publishers/s3_spec.rb
+++ b/spec/lib/solidus_feeds/publishers/s3_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+RSpec.describe SolidusFeeds::Publishers::S3 do
+  let(:io) { StringIO.new }
+  let(:client) { Aws::S3::Client.new(stub_responses: true) }
+  let(:generator) {
+    ->(io) {
+      csv = CSV.new(io)
+      csv << ["some", "data"]
+      csv << ["another", "line"]
+    }
+  }
+
+  describe '#call' do
+    it 'correctly uploads the generated content to S3' do
+      s3_publisher = described_class.new(object_key: 'my_feed.xml', bucket: 'dummy_bucket', client: client)
+
+      response = s3_publisher.call do |io|
+        generator.call(io)
+      end
+
+      expect(response).to be_instance_of(Aws::S3::Types::PutObjectOutput)
+    end
+
+    it 'raises an error if the generator does not generate anything' do
+      s3_publisher = described_class.new(object_key: 'my_feed.xml', bucket: 'dummy_bucket', client: client)
+
+      expect {
+        s3_publisher.call do |io|
+          io << ""
+        end
+      }.to raise_error SolidusFeeds::Publishers::S3::NoContentError
+    end
+  end
+end


### PR DESCRIPTION
Closes #3 

This PR aims implement a feed publisher for AWS S3. With this we'll be able to upload the generated feeds to S3 right after generation.