### PR TITLE
Make class definition compatible with classic autoloader

### DIFF
--- a/lib/solidus_feeds/feed.rb
+++ b/lib/solidus_feeds/feed.rb
@@ -1,19 +1,21 @@
 # frozen_string_literal: true
 
-class SolidusFeeds::Feed
-  attr_accessor :generator, :publisher
+module SolidusFeeds
+  class Feed
+    attr_accessor :generator, :publisher
 
-  def initialize
-    yield(self) if block_given?
-  end
+    def initialize
+      yield(self) if block_given?
+    end
 
-  def generate(output)
-    generator.call(output)
-  end
+    def generate(output)
+      generator.call(output)
+    end
 
-  def publish
-    publisher.call do |output|
-      generate(output)
+    def publish
+      publisher.call do |output|
+        generate(output)
+      end
     end
   end
 end


### PR DESCRIPTION
This prevents `uninitialized constant SolidusFeeds (NameError)` error when using classic autoloader.