### PR TITLE
Fix namespaces and host

### DIFF
--- a/lib/solidus_feeds/configuration.rb
+++ b/lib/solidus_feeds/configuration.rb
@@ -41,15 +41,15 @@ module SolidusFeeds
     end
 
     def title
-      @title ||= Spree::Store.default.name
+      @title ||= ::Spree::Store.default.name
     end
 
     def link
-      @link ||= "https://#{Spree::Store.default.url}"
+      @link ||= "https://#{::Spree::Store.default.url}"
     end
 
     def description
-      @description ||= "Find out about new products on https://#{Spree::Store.default.url} first!"
+      @description ||= "Find out about new products on https://#{::Spree::Store.default.url} first!"
     end
 
     def language

--- a/lib/solidus_feeds/generators/google_merchant.rb
+++ b/lib/solidus_feeds/generators/google_merchant.rb
@@ -75,7 +75,7 @@ module SolidusFeeds
       end
 
       def price(product)
-        Spree::Money.new(product.price).money.format(symbol: false, with_currency: true)
+        ::Spree::Money.new(product.price).money.format(symbol: false, with_currency: true)
       end
 
       # Must be "in stock", "preorder" or "out of stock"
@@ -99,7 +99,7 @@ module SolidusFeeds
       private
 
       def spree_routes
-        @spree_routes ||= Spree::Core::Engine.routes.url_helpers
+        @spree_routes ||= ::Spree::Core::Engine.routes.url_helpers
       end
     end
   end

--- a/lib/solidus_feeds/generators/google_merchant.rb
+++ b/lib/solidus_feeds/generators/google_merchant.rb
@@ -64,7 +64,7 @@ module SolidusFeeds
         return unless product.images.any?
 
         attachment_url = product.images.first.attachment.url(:large)
-        asset_host = ActionController::Base.asset_host
+        asset_host = ActionController::Base.asset_host || host
 
         URI.join(asset_host, attachment_url).to_s
       end


### PR DESCRIPTION
This solves a couple of bugs I've found:

- The `Spree` namespace wasn't correctly referenced in some places
- There could be some cases where the Rails asset host is not set, so it made sense to default to the host set for the generator