### PR TITLE
Remove unplanned publishers

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,6 @@ SolidusFeeds.config.register :all_products do |feed|
 end
 ```
 
-### ActiveStorage
-### Rails cache
-
 ### Static file
 
 To publish the feed directly from an app directory (e.g. the `public` directory), you can use the
@@ -147,8 +144,6 @@ SolidusFeeds.config.register :all_products do |feed|
   )
 end
 ```
-
-### FTP
 
 ## Builtin Marketplace format generators
 


### PR DESCRIPTION
Since we're closing in with the first release, we need to ship the gem with a README listing only the supported or planned publishers.

This builds upon #17 , which updates the README with new documentation.