### PR TITLE
Add documentation on Facebook feed format

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,7 @@ end
 
 ## Builtin Marketplace format generators
 
-- Google Merchant
-- Facebook and Instagram (work in progress)
+- Google Merchant XML: compatible with Google Merchant and Facebook/Instagram feeds
 
 ## Creating your own Generators and Publishers
 


### PR DESCRIPTION
Ref #5

Since also Facebook internally uses the same XML format designed by Google, we can use the same generator also for those feeds.

This PR adds this piece of information to the README.